### PR TITLE
feat(scripts): Harden Deployment Scripts and Add Dry-Run + Network Selection Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,39 @@ These checks are also enforced in CI and will fail the build if there are format
 
 ## Deployment
 
-The repository includes enhanced deployment scripts for deploying Soroban smart contracts to Stellar's testnet and mainnet.  
+The repository now includes a hardened deployment script for Soroban smart contracts:
 
-Scripts:  
-- `scripts/deploy_testnet.sh`  
-- `scripts/deploy_mainnet.sh`  
+- `scripts/deploy.sh` (supports local, testnet, and mainnet)
 
-These scripts include safety features, argument parsing, environment validation, dependency checks, and dry-run support.
+### Deployment Script Usage
+
+Run the script from the project root:
+
+```bash
+./scripts/deploy.sh --network <local|testnet|mainnet> --contract <name> --wasm <path> [--dry-run]
+```
+
+#### Flags
+| Flag                   | Description                                                                 |
+|------------------------|-----------------------------------------------------------------------------|
+| `--network <network>`  | Specify which network to deploy to (`local`, `testnet`, or `mainnet`).        |
+| `--contract <name>`    | Name of the contract to deploy.                                              |
+| `--wasm <path>`        | Path to the WASM file to deploy.                                             |
+| `--dry-run`            | Simulate the deployment steps without executing them.                        |
+
+#### Environment Configuration
+Network-specific settings (URLs, keys, etc.) are managed via environment files named `.env.<network>`. The script will automatically load the correct file based on the `--network` flag.
+
+#### Dry-Run Mode
+When `--dry-run` is specified, the script prints the deployment steps but does not execute them.
+
+#### Example
+```bash
+./scripts/deploy.sh --network testnet --contract certificate --wasm contracts/certificate/target/wasm32-unknown-unknown/release/certificate.optimized.wasm --dry-run
+```
+
+#### Cross-Platform Compatibility
+The scripts are linted and compatible with macOS and Linux.
 
 ### Before Deploying
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,16 +56,29 @@ cargo test
 
 ## Deployment
 
-For testnet deployment:
 
-```
-./scripts/deploy_testnet.sh
+### Hardened Deployment Script
+
+Use the new deployment script for all environments:
+
+```bash
+./scripts/deploy.sh --network <local|testnet|mainnet> --contract <name> --wasm <path> [--dry-run]
 ```
 
-For mainnet deployment (requires authorization):
+#### Flags
+| Flag                   | Description                                                                 |
+|------------------------|-----------------------------------------------------------------------------|
+| `--network <network>`  | Specify which network to deploy to (`local`, `testnet`, or `mainnet`).        |
+| `--contract <name>`    | Name of the contract to deploy.                                              |
+| `--wasm <path>`        | Path to the WASM file to deploy.                                             |
+| `--dry-run`            | Simulate the deployment steps without executing them.                        |
 
-```
-./scripts/deploy_mainnet.sh
+#### Environment Configuration
+Create environment files named `.env.local`, `.env.testnet`, or `.env.mainnet` to store network-specific variables (e.g., URLs, keys). The script loads the appropriate file based on the `--network` flag.
+
+#### Example
+```bash
+./scripts/deploy.sh --network testnet --contract certificate --wasm contracts/certificate/target/wasm32-unknown-unknown/release/certificate.optimized.wasm --dry-run
 ```
 
 ## Release Process

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Common functions for deployment scripts
+
+set -e
+
+# Print usage for scripts
+print_usage() {
+  echo "Usage: $0 --network <local|testnet|mainnet> [--dry-run] --contract <name> --wasm <path>"
+}
+
+# Load environment variables for the selected network
+load_env() {
+  local network="$1"
+  local env_file=".env.$network"
+  if [ -f "$env_file" ]; then
+    set -a
+    source "$env_file"
+    set +a
+  else
+    echo "Error: Environment file $env_file not found."
+    exit 1
+  fi
+}
+
+# Dry-run wrapper
+run_or_dry() {
+  if [ "$DRY_RUN" = true ]; then
+    echo "[DRY-RUN] $@"
+  else
+    eval "$@"
+  fi
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Hardened deployment script for Soroban smart contracts
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+NETWORK=""
+DRY_RUN=false
+CONTRACT=""
+WASM_PATH=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --network)
+      NETWORK="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --contract)
+      CONTRACT="$2"
+      shift 2
+      ;;
+    --wasm)
+      WASM_PATH="$2"
+      shift 2
+      ;;
+    *)
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$NETWORK" || -z "$CONTRACT" || -z "$WASM_PATH" ]]; then
+  print_usage
+  exit 1
+fi
+
+load_env "$NETWORK"
+
+# Example: Soroban CLI deploy command
+DEPLOY_CMD="soroban contract deploy --wasm $WASM_PATH --network $NETWORK --contract-name $CONTRACT"
+run_or_dry "$DEPLOY_CMD"
+
+echo "Deployment script completed."


### PR DESCRIPTION
## Harden Deployment Scripts and Add Dry-Run + Network Selection Support

### Why
Ensures safer, more predictable deployments across environments. Addresses issue #70.

### Changes
- New scripts: `scripts/common.sh`, `scripts/deploy.sh`
- Flags: `--network`, `--dry-run`, `--contract`, `--wasm`
- Loads environment config from `.env.<network>`
- Dry-run mode prints steps without executing
- Documentation updated in README.md and docs/development.md
- Scripts linted and compatible with macOS/Linux

Closed: #84 
