### PR TITLE
ci: enforce visual regression against committed Playwright baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,6 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
-      - name: Generate visual baselines in CI
-        run: npm run visual:test:update
-
       - name: Run visual regression tests
         run: npm run visual:test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "StrellerMinds-work",
+  "name": "StrellerMinds-SmartContracts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/visual-tests/README.md
+++ b/visual-tests/README.md
@@ -15,7 +15,7 @@ From repository root:
 
 ```bash
 npm install
-npm run visual:test:update
+npm run visual:test:update   # update committed baseline screenshots when UI changes are intentional
 npm run visual:test
 ```
 
@@ -24,6 +24,8 @@ To inspect diffs:
 ```bash
 npm run visual:test:report
 ```
+
+> Note: CI runs visual tests against the committed baselines and does not update snapshots automatically.
 
 ## CI Integration
 


### PR DESCRIPTION
Close #459 

## PR Description

### Summary
Add and harden visual regression testing for the repository by updating CI integration and documentation.

### Changes
- Removed baseline regeneration from CI by deleting `npm run visual:test:update` from ci.yml
- Ensured CI now runs `npm run visual:test` only, validating against committed Playwright baseline screenshots
- Clarified manual baseline update workflow in README.md
- Confirmed visual regression suite already includes:
  - screenshot comparison testing
  - cross-browser coverage (Chromium, Firefox, WebKit)
  - component-level visual assertions
  - HTML diff report output

### Why
This ensures CI fails on unintended UI changes rather than silently re-creating baselines, meeting the visual regression requirement and preserving deterministic snapshot validation.

### Testing
- `npm ci`
- `npm run visual:test`
- `npm run visual:test:report`

-