### PR TITLE
Add/blue green deploy workflow

### DIFF
--- a/.github/workflows/blue-green-deploy.yml
+++ b/.github/workflows/blue-green-deploy.yml
@@ -1,0 +1,63 @@
+name: Blue-Green Deploy to EKS
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}/myapp
+      K8S_NAMESPACE: default
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      EKS_CLUSTER_NAME: ${{ secrets.EKS_CLUSTER_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        if: env.AWS_REGION != ''
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            "${{ env.IMAGE_NAME }}:latest"
+            "${{ env.IMAGE_NAME }}:${{ github.sha }}"
+      - name: Configure kubectl (EKS)
+        if: env.AWS_REGION != ''
+        run: |
+          aws eks update-kubeconfig --region ${{ secrets.AWS_REGION }} --name ${{ secrets.EKS_CLUSTER_NAME }}
+
+      - name: Deploy (Blue-Green)
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          K8S_NAMESPACE: ${{ env.K8S_NAMESPACE }}
+        run: |
+          chmod +x ./scripts/blue-green-deploy.sh
+          ./scripts/blue-green-deploy.sh "$IMAGE" "$K8S_NAMESPACE"
+
+      - name: Notify on failure and rollback
+        if: failure()
+        run: |
+          chmod +x ./scripts/blue-green-rollback.sh
+          ./scripts/blue-green-rollback.sh "$K8S_NAMESPACE"

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,49 @@
+# Adding repository secrets for CI
+
+Use repository secrets to store AWS credentials and cluster name for GitHub Actions. Do NOT commit any keys or kubeconfig files.
+
+Recommended secrets to add (names used by the workflow):
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `EKS_CLUSTER_NAME`
+
+Add via GitHub UI:
+
+1. Go to your repository on GitHub.
+2. Settings → Secrets and variables → Actions → New repository secret.
+3. Add each secret with the names above.
+
+Add via GitHub CLI (`gh`) if you have it authenticated:
+
+```bash
+gh secret set AWS_ACCESS_KEY_ID -b "<your-access-key-id>"
+gh secret set AWS_SECRET_ACCESS_KEY -b "<your-secret-access-key>"
+gh secret set AWS_REGION -b "us-east-1"
+gh secret set EKS_CLUSTER_NAME -b "strellerminds-staging"
+```
+
+Local testing (temporary environment variables):
+
+For Bash/WSL:
+```bash
+export AWS_ACCESS_KEY_ID="<your-access-key-id>"
+export AWS_SECRET_ACCESS_KEY="<your-secret-access-key>"
+export AWS_REGION="us-east-1"
+export EKS_CLUSTER_NAME="strellerminds-staging"
+```
+
+For PowerShell (temporary for session):
+```powershell
+$env:AWS_ACCESS_KEY_ID="<your-access-key-id>"
+$env:AWS_SECRET_ACCESS_KEY="<your-secret-access-key>"
+$env:AWS_REGION="us-east-1"
+$env:EKS_CLUSTER_NAME="strellerminds-staging"
+```
+
+After setting secrets or environment variables, the workflow can be triggered manually from Actions (select the `Blue-Green Deploy to EKS` workflow and click "Run workflow") or by pushing to `main`.
+
+PR link (branch pushed by me):
+
+https://github.com/oscarj007/StrellerMinds-SmartContracts/pull/new/add/blue-green-deploy-workflow


### PR DESCRIPTION
Summary

Adds a complete blue-green deploy workflow for EKS with manual dispatch, kubeconfig configuration, image build/push, post-switch health checks and automatic rollback.

What changed

 .github/workflows/blue-green-deploy.yml: workflow (manual workflow_dispatch, build/push, aws eks update-kubeconfig, deploy + rollback)
[blue-green-deploy.sh](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [blue-green-rollback.sh](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [integration_test.sh](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): deploy/rollback/integration test scripts
[k8s](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) manifests: deployment + service templates used by the workflow
[IAM_CI_POLICY.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [SECRETS.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): instructions for IAM, OIDC and repository secrets

Why

Provide a safe blue/green rollout that lets owners run deployments from Actions or CI, verify health via service DNS, and automatically rollback on failure.
Required repository secrets

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_REGION
EKS_CLUSTER_NAME

How to run (owner)

From Actions UI: select Blue-Green Deploy to EKS → Run workflow (choose branch/main).
Or merge to main (push will trigger it).
Example manual/test (locally with kube access):
Testing notes

Run in a non-prod namespace first (e.g., staging).
Ensure the service myapp-service exists and pods expose /healthz on the probe port.
The workflow will:
build and push image
update kubeconfig via aws eks update-kubeconfig
deploy the new colored deployment (myapp-blue / myapp-green)
patch myapp-service selector to the new version
run post-switch health checks (ephemeral curl pod)
rollback automatically if checks fail
Rollback / Recovery

Automatic rollback runs on failure.
Manual rollback:
Security & recommendations

Do NOT commit AWS keys or kubeconfig.
Prefer GitHub Actions OIDC to avoid long-lived AWS keys (see [IAM_CI_POLICY.md](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Use least-privilege IAM role; map role to a restricted Kubernetes ClusterRole instead of system:masters where possible.
Checklist before merging

 Add the required repository secrets listed above.
 Confirm [deployment-template.yaml](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [service.yaml](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) match the running cluster (namespaces, probe path/port).

closes #460